### PR TITLE
fix(sequel): configure UserSeasonMatch joins correctly

### DIFF
--- a/server/models/user_season.rb
+++ b/server/models/user_season.rb
@@ -1,7 +1,7 @@
-class UserSeason < Sequel::Model
+class UserSeason < Sequel::Model(:users_seasons)
   plugin :validation_helpers
-  one_to_one :user
-  one_to_one :season
+  many_to_one :user
+  many_to_one :season
   def validate
     validates_unique [:user_id, :season_id]
     super

--- a/server/models/user_season_match.rb
+++ b/server/models/user_season_match.rb
@@ -1,15 +1,9 @@
 #TODO finish this class and utilize in other related classes / controllers
 class UserSeasonMatch < Sequel::Model(:users_seasons_matches)
   plugin :validation_helpers
-  many_to_one :matches, :class => :Match
-#  many_to_many :wtf, :class => :UserSeason, :dataset => (proc do |r|
-#    r.associated_dataset.select_all(:user_season)
-#  end)
-# Sequel REFUSES to let me make this join no matter which way I try it due to some random primary key 
-#  one_to_one :user_season
-#  one_to_one :user, :dataset => (proc do |r|
-#    User.where(id: $DB[:user_season].where(id: self.user_season_id).select(:user_id))
-#  end), :class => User
+  many_to_one :match
+  many_to_one :user_season
+  one_through_one :user, :join_table => :users_seasons, :left_primary_key => :user_season_id, :left_key => :id
   def validate
     validates_unique [:user_season_id, :match_id]
     super


### PR DESCRIPTION
This fixes the joins used by UserSeason and UserSeasonMatch.

Ref: https://github.com/jeremyevans/sequel/blob/master/doc/association_basics.rdoc

```
irb(main):009:0> UserSeasonMatch.all[0].user_season.season.name
I, [2015-04-25T11:18:54.265145 #18642]  INFO -- : (0.000321s) SELECT * FROM `users_seasons_matches`
I, [2015-04-25T11:18:54.265613 #18642]  INFO -- : (0.000280s) SELECT * FROM `users_seasons` WHERE `id` = 1
I, [2015-04-25T11:18:54.266519 #18642]  INFO -- : (0.000739s) SELECT * FROM `seasons` WHERE `id` = 1
=> "Season"
irb(main):010:0> UserSeasonMatch.all[0].match
I, [2015-04-25T11:18:58.040916 #18642]  INFO -- : (0.000353s) SELECT * FROM `users_seasons_matches`
I, [2015-04-25T11:18:58.041765 #18642]  INFO -- : (0.000667s) SELECT * FROM `matches` WHERE `id` = 1
=> #<Match @values={:id=>1, :created_at=>2015-04-25 09:57:12 -0400, :updated_at=>2015-04-25 09:57:12 -0400, :scheduled_for=>2015-04-25 13:56:24 -0400, :completed=>nil, :season_match_group_id=>1, :description=>"Ben vs Zach"}>
irb(main):011:0> UserSeasonMatch.all[0].user.username
I, [2015-04-25T11:19:02.289105 #18642]  INFO -- : (0.000323s) SELECT * FROM `users_seasons_matches`
I, [2015-04-25T11:19:02.290061 #18642]  INFO -- : (0.000714s) SELECT `users`.* FROM `users` INNER JOIN `users_seasons` ON (`users_seasons`.`user_id` = `users`.`id`) WHERE (`users_seasons`.`id` = 1) LIMIT 1
=> "bheiskell"
```