### PR TITLE
feat: add name and (exact) email fields to user search

### DIFF
--- a/frontend/scss/app.scss
+++ b/frontend/scss/app.scss
@@ -4,6 +4,38 @@
 .purple-text {
   color: #6d426d;
 }
+.user-typeahead {
+  position: relative;
+  width: 250px;
+}
+.user-typeahead .avatar {
+  display: inline-block;
+}
+.user-typeahead span {
+  padding-left: 1em;
+}
+.user-typeahead span:first-of-type {
+  position: absolute;
+  top: 20%;
+}
+.user-typeahead span:last-of-type {
+  position: absolute;
+  bottom: 20%;
+}
+.avatar {
+    display: block;
+    overflow: hidden;
+}
+.avatar-64 {
+    height: 64px;
+    width: 64px;
+}
+.avatar img {
+    display: block;
+    min-width: 100%;
+    min-height: 100%;
+    -ms-interpolation-mode: bicubic; /* Scaled images look a bit better in IE now */
+}
 #avatar-selector {
   cursor: pointer;
   position: relative;

--- a/frontend/views/season-manage.html
+++ b/frontend/views/season-manage.html
@@ -30,6 +30,7 @@
             type="text"
             class="form-control"
             typeahead="user as user.username for user in findMembersMatching($viewValue)"
+            typeahead-template-url="user-typeahead.html"
             id="newMemberLookup"
             ng-model="newMember">
         </div>

--- a/frontend/views/user-typeahead.html
+++ b/frontend/views/user-typeahead.html
@@ -1,0 +1,9 @@
+<a>
+  <div class="user-typeahead">
+    <div class="avatar avatar-64">
+      <img ng-src="{{match.model.avatar_url}}" width="64" />
+    </div>
+    <span bind-html-unsafe="match.label | typeaheadHighlight:query"></span>
+    <span>{{match.model.name}}</span>
+  </div>
+</a>

--- a/server/controllers/auth.rb
+++ b/server/controllers/auth.rb
@@ -16,7 +16,7 @@ class AuthController < ApplicationController
           Sequel.ilike(:name, '%' + params[:matching] + '%') |
           Sequel.ilike(:email, params[:matching])
         ))
-        .to_json(root: true, :only => [:id, :username, :name, :avatar_url])
+        .to_json(root: true, :only => User.public_attrs)
     else
       requires_role! :admin
       User.to_json(root: true, exclude: :avatar)

--- a/server/controllers/auth.rb
+++ b/server/controllers/auth.rb
@@ -11,8 +11,12 @@ class AuthController < ApplicationController
     if params[:limitted]
       requires_login!
       params[:matching] ||= ""
-      User.where(Sequel.expr(active: true) & Sequel.like(:username, '%' + params[:matching] + '%'))
-        .to_json(root: true, :only => [:username, :id])
+      User.where(Sequel.expr(active: true) & (
+          Sequel.ilike(:username, '%' + params[:matching] + '%') |
+          Sequel.ilike(:name, '%' + params[:matching] + '%') |
+          Sequel.ilike(:email, params[:matching])
+        ))
+        .to_json(root: true, :only => [:id, :username, :name, :avatar_url])
     else
       requires_role! :admin
       User.to_json(root: true, exclude: :avatar)

--- a/server/models/user.rb
+++ b/server/models/user.rb
@@ -43,6 +43,6 @@ class User < Sequel::Model
   end
   # TODO add a concept of visibility that all classes can utilize
   def self.public_attrs
-    [:username, :id]
+    [:id, :username, :name, :avatar_url, :catchphrase]
   end
 end

--- a/spec/auth_spec.rb
+++ b/spec/auth_spec.rb
@@ -47,7 +47,7 @@ describe "Authentication" do
       authorize 'unit-test-account', 'unit-test-password'
       post '/me', {
         :user => {
-          :name => 'Unit Test',
+          :name => 'Unit Tester',
           :email => 'unit-test-email@example.com',
           :passwordCurrent => 'unit-test-password',
           :password => 'unit-test-new-password',
@@ -56,6 +56,48 @@ describe "Authentication" do
       }
       expect(last_response.status).to equal(200)
       expect(JSON.parse(last_response.body)).to have_key("id")
+    end
+
+    def verify_user_search_response(body)
+      response = JSON.parse(last_response.body)
+      expect(response).to have_key("users")
+      expect(response["users"].size).to be(1)
+      expect(response["users"][0]).to include("username" => "unit-test-account")
+      expect(response["users"][0]).to include("name" => "Unit Tester")
+    end
+
+    it "should filter by username insensitive" do
+      authorize 'unit-test-account', 'unit-test-new-password'
+      get '/users', {
+        :limitted => true,
+        :matching => 'Account'
+      }
+      verify_user_search_response(last_response.body)
+    end
+
+    it "should filter by name insensitive" do
+      authorize 'unit-test-account', 'unit-test-new-password'
+      get '/users', {
+        :limitted => true,
+        :matching => 'tester'
+      }
+      verify_user_search_response(last_response.body)
+    end
+
+    it "should filter by email exact match" do
+      authorize 'unit-test-account', 'unit-test-new-password'
+      get '/users', {
+        :limitted => true,
+        :matching => 'unit-test-email@example.co'
+      }
+      response = JSON.parse(last_response.body)
+      expect(response).to have_key("users")
+      expect(response["users"].size).to be(0)
+      get '/users', {
+        :limitted => true,
+        :matching => 'unit-test-email@example.com'
+      }
+      verify_user_search_response(last_response.body)
     end
   end
 end


### PR DESCRIPTION
Didn't have much time to hack tonight. All I got done was the search with an avatar and their real name.

Addresses issue #15 and partly addresses #19 