### PR TITLE
fix(match): sort match members consistently

### DIFF
--- a/server/models/match.rb
+++ b/server/models/match.rb
@@ -2,7 +2,7 @@ class Match < Sequel::Model
   plugin :validation_helpers
   many_to_one :season_match_group, :class => :SeasonMatchGroup, :key => :season_match_group_id
   # TODO i think this should end with "es" since its a *_to_many
-  one_to_many :user_season_match, :class => :UserSeasonMatch
+  one_to_many :user_season_match, :class => :UserSeasonMatch, :order => :user_season_id
   def validate
     validates_integer :best_of
     validates_presence [:scheduled_for, :best_of]


### PR DESCRIPTION
Particularly when updating a match's results, we need to make sure the user's
come back in a consistent order. Otherwise when you click increment on game
wins, it may reorder. This resulted in me entering 1-1 when I intended to enter
2-0.

Fixes issue #30