### PR TITLE
feat(email): add user create, match member add/remove emails

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -21,7 +21,7 @@ Metrics/ModuleLength:
 # Offense count: 2
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 298
+  Max: 400
 
 # Offense count: 1
 Metrics/CyclomaticComplexity:

--- a/server/controllers/auth.rb
+++ b/server/controllers/auth.rb
@@ -118,7 +118,7 @@ class AuthController < ApplicationController
     json_halt 400, new_user.errors unless new_user.valid?
     new_user.save
     status 201
-    logger.info "#{new_user.username} successfully registered"
+    email_welcome(new_user)
     json id: new_user.id
   end
   put '/me/slack' do

--- a/server/models/match.rb
+++ b/server/models/match.rb
@@ -5,12 +5,26 @@ class Match < Sequel::Model
   one_to_many :user_season_match, class: :UserSeasonMatch, order: :user_season_id
   def validate
     validates_integer :best_of
-    validates_presence [:scheduled_for, :best_of]
+    validates_presence [:scheduled_for, :best_of, :description]
     super
   end
 
   def before_validation
     super
     self.best_of = 3 if best_of.nil?
+  end
+
+  def member?(user)
+    user_id = if user.is_a? User
+                user.id
+              else
+                user
+              end
+    # user season match is like 'match member'
+    UserSeasonMatch.join(:users_seasons, id: :user_season_id).where(user_id: user_id, match_id: id).count != 0
+  end
+
+  def title
+    "#{season_match_group.season.name} > #{season_match_group.name} > #{description}"
   end
 end

--- a/server/tests/controllers/auth_spec.rb
+++ b/server/tests/controllers/auth_spec.rb
@@ -11,8 +11,9 @@ describe 'Authentication' do
     AuthController
   end
 
-  def email_deliveries
-    Mail::TestMailer.deliveries
+  before(:each) do
+    clear_deliveries
+    expect(email_deliveries.count).to eq(0)
   end
 
   context 'unauthenticated' do
@@ -26,10 +27,10 @@ describe 'Authentication' do
       }
       expect(last_response.status).to equal(201)
       expect(JSON.parse(last_response.body)).to have_key('id')
+      expect(email_deliveries.count).to eq(1)
     end
 
     it 'should allow resetting a password' do
-      expect(email_deliveries.count).to eq(0)
       post '/forgot-password', {}
       expect(last_response.status).to eq(400)
       expect(JSON.parse(last_response.body)).to include('errors' => 'No user object found in request payload')

--- a/server/tests/controllers/match_spec.rb
+++ b/server/tests/controllers/match_spec.rb
@@ -1,0 +1,159 @@
+require_relative '../spec_helper'
+require_relative '../../controllers/match'
+
+describe 'Match' do
+  def app
+    MatchController
+  end
+
+  def password
+    'test-password'
+  end
+
+  before(:all) do
+    @user = User.new(
+      username: 'match_spec_tests_user',
+      password: password,
+      email: 'match_spec_tests_user@magic-stick.herokuapp.com',
+      name: 'match specuser'
+    )
+    raise 'failed to save user' unless @user.save
+    @user2 = User.new(
+      username: 'match_spec_tests_user2',
+      password: password,
+      email: 'match_spec_tests_user2@magic-stick.herokuapp.com',
+      name: 'match specuser2'
+    )
+    raise 'failed to save user2' unless @user2.save
+    @season = Season.new(
+      name: 'match_spec_tests',
+      description: 'sweet season',
+      invite_only: true,
+      owner: @user,
+      starts: Time.now,
+      ends: (Time.now + 5_000)
+    )
+    raise 'failed to save season' unless @season.save
+    @smg = SeasonMatchGroup.new(season: @season, name: 'another-group')
+    raise 'failed to save smg' unless @smg.save
+    @match = Match.new(season_match_group: @smg, best_of: 3, scheduled_for: Time.now + 3_124, description: 'sweetness')
+    raise 'failed to save match' unless @match.save
+  end
+
+  before(:each) do
+    clear_deliveries
+    expect(email_deliveries.count).to eq(0)
+  end
+
+  it 'should allow season creation' do
+    authorize @user.username, password
+    post '/seasons', season: {
+      starts: Time.now,
+      ends: Time.now + 5_000,
+      description: 'test season',
+      invite_only: true,
+      name: 'match spec test season'
+    }
+    expect(last_response.status).to eq(201)
+    season = JSON.parse(last_response.body)
+    expect(season).to have_key('id')
+    expect(Season.find(id: season['id'])).not_to be_nil
+  end
+
+  it 'should allow adding a user to a season' do
+    authorize @user.username, password
+    expect(@season.member?(@user2)).to eq(false)
+    put "/seasons/#{@season.id}/members/#{@user2.id}"
+    expect(@season.member?(@user2)).to eq(true)
+    expect(last_response.status).to eq(204)
+    expect(email_deliveries.count).to eq(2)
+    expect(deliveries).to include(@user.email, @user2.email)
+  end
+
+  it 'should allow removing a user from a season' do
+    authorize @user.username, password
+    expect(@season.member?(@user2)).to eq(true)
+    delete "/seasons/#{@season.id}/members/#{@user2.id}"
+    expect(@season.member?(@user2)).to eq(false)
+    expect(last_response.status).to eq(204)
+    expect(email_deliveries.count).to eq(2)
+    expect(deliveries).to include(@season.owner.email, @user2.email)
+  end
+
+  it 'should allow creating and deleting match groups' do
+    authorize @user.username, password
+    post "/seasons/#{@season.id}/match-groups", name: 'fancy-group'
+    expect(last_response.status).to eq(201)
+    smg = JSON.parse(last_response.body)
+    expect(smg).to have_key('id')
+    expect(@season.season_match_groups.last.name).to eq('fancy-group')
+
+    delete "/seasons/#{@season.id}/match-groups/#{smg['id']}"
+    expect(last_response.status).to eq(204)
+    @season.reload
+    expect(@season.season_match_groups.last.name).not_to eq('fancy-group')
+  end
+
+  it 'should allow creating and deleting matches' do
+    authorize @user.username, password
+    post "/seasons/#{@season.id}/match-groups/#{@smg.id}/matches", match: {
+      best_of: 3,
+      scheduled_for: Time.now + 1_000,
+      description: 'new match'
+    }
+    expect(last_response.status).to eq(201)
+    match = JSON.parse(last_response.body)
+    expect(match).to have_key('id')
+    expect(@smg.matches.last.id).to eq(match['id'])
+
+    delete "/seasons/#{@season.id}/match-groups/#{@smg.id}/matches/#{match['id']}"
+    expect(last_response.status).to eq(204)
+    @smg.reload
+    expect(@smg.matches.last.id).not_to eq(match['id'])
+  end
+
+  it 'should allow adding and removing a user from a match' do
+    authorize @user.username, password
+    put "/seasons/#{@season.id}/match-groups/#{@smg.id}/matches/#{@match.id}/members/#{@user2.id}"
+    expect(last_response.status).to eq(400)
+    body = JSON.parse(last_response.body)
+    expect(body).to have_key('errors')
+    expect(body['errors']).to eq("User #{@user2.id} isn't a member of season #{@season.id}")
+
+    @season.add_member @user2
+    clear_deliveries
+    expect(@match.member?(@user2)).to eq(false)
+    put "/seasons/#{@season.id}/match-groups/#{@smg.id}/matches/#{@match.id}/members/#{@user2.id}"
+    expect(last_response.status).to eq(204)
+    @match.reload
+    expect(@match.user_season_match.last.user.id).to eq(@user2.id)
+    expect(@match.member?(@user2)).to eq(true)
+    expect(email_deliveries.count).to eq(1)
+    expect(deliveries).to include(@user2.email)
+
+    # make sure we don't re-email
+    clear_deliveries
+    put "/seasons/#{@season.id}/match-groups/#{@smg.id}/matches/#{@match.id}/members/#{@user2.id}"
+    @match.reload
+    expect(last_response.status).to eq(204)
+    expect(@match.member?(@user2)).to eq(true)
+    expect(email_deliveries.count).to eq(0)
+
+    clear_deliveries
+    delete "/seasons/#{@season.id}/match-groups/#{@smg.id}/matches/#{@match.id}/members/#{@user2.id}"
+    expect(last_response.status).to eq(204)
+    @match.reload
+    expect(@match.user_season_match.last).to be_nil
+    expect(@match.member?(@user2)).to eq(false)
+    expect(email_deliveries.count).to eq(1)
+    expect(deliveries).to include(@user2.email)
+
+    # make sure we don't re-email
+    clear_deliveries
+    delete "/seasons/#{@season.id}/match-groups/#{@smg.id}/matches/#{@match.id}/members/#{@user2.id}"
+    @match.reload
+    expect(last_response.status).to eq(204)
+    expect(@match.member?(@user2)).to eq(false)
+    expect(email_deliveries.count).to eq(0)
+  end
+end

--- a/server/tests/models/match_spec.rb
+++ b/server/tests/models/match_spec.rb
@@ -1,7 +1,45 @@
 require_relative '../spec_helper'
 require_relative '../../models/match'
+require_relative '../../helpers/slack'
+require_relative '../../helpers/link'
 
 describe 'Match' do
+  include Slack
+  include Link
+  def password
+    'test-password'
+  end
+
+  before(:all) do
+    @user = User.new(
+      username: 'matchm_spec_tests_user',
+      password: password,
+      email: 'matchm_spec_tests_user@magic-stick.herokuapp.com',
+      name: 'matchm specuser'
+    )
+    raise 'failed to save user' unless @user.save
+    @user2 = User.new(
+      username: 'matchm_spec_tests_user2',
+      password: password,
+      email: 'matchm_spec_tests_user2@magic-stick.herokuapp.com',
+      name: 'matchm specuser2'
+    )
+    raise 'failed to save user2' unless @user2.save
+    @season = Season.new(
+      name: 'matchm_spec_tests',
+      description: 'sweet season',
+      invite_only: true,
+      owner: @user,
+      starts: Time.now,
+      ends: (Time.now + 5_000)
+    )
+    raise 'failed to save season' unless @season.save
+    @smg = SeasonMatchGroup.new(season: @season, name: 'another-groupm')
+    raise 'failed to save smg' unless @smg.save
+    @match = Match.new(season_match_group: @smg, best_of: 3, scheduled_for: Time.now + 1_100, description: 'somethin')
+    raise 'failed to save match' unless @match.save
+  end
+
   context 'validations' do
     it 'should set and check reasonable defaults' do
       match = Match.new
@@ -11,5 +49,15 @@ describe 'Match' do
       expect(match.errors[:scheduled_for]).not_to be_nil
       expect(match.best_of).not_to be_nil
     end
+  end
+
+  it 'should generate a valid fqtitle' do
+    expect(@match.title).to eq('matchm_spec_tests > another-groupm > somethin')
+    expect(slack_escape(@match.title)).to eq('matchm_spec_tests &gt; another-groupm &gt; somethin')
+  end
+
+  it 'should check match membership' do
+    expect(@match.member?(@user)).to be(false)
+    expect(@match.member?(@user2)).to be(false)
   end
 end

--- a/server/tests/spec_helper.rb
+++ b/server/tests/spec_helper.rb
@@ -5,6 +5,7 @@ Coveralls.wear!
 
 require_relative '../../app'
 
+ENV['SLACK_WEBHOOK_URL'] = 'http://localhost:12345/cool'
 ENV['SECRET'] = 'test secret'
 ENV['HMAC_SECRET'] = 'hmac test secret'
 
@@ -13,3 +14,19 @@ module RSpecMixin
 end
 
 RSpec.configure { |c| c.include RSpecMixin }
+
+def clear_deliveries
+  Mail::TestMailer.deliveries.clear
+end
+
+def delivery_count
+  Mail::TestMailer.deliveries.count
+end
+
+def deliveries
+  Mail::TestMailer.deliveries.map(&:to).flatten
+end
+
+def email_deliveries
+  Mail::TestMailer.deliveries
+end


### PR DESCRIPTION
This also cleans up some of the match membership logic, adds
tests for various match controller routes, and adds a match.title
function.